### PR TITLE
CodeQl fixes

### DIFF
--- a/WebServiceStudio/MainForm.cs
+++ b/WebServiceStudio/MainForm.cs
@@ -107,7 +107,6 @@ namespace WebServiceStudio
             if (buttonGet.Text == "Get")
             {
                 ClearAllTabs();
-                TabPage selectedTab = tabMain.SelectedTab;
                 tabMain.SelectedTab = tabPageMessage;
                 string text = textEndPointUri.Text;
                 wsdl.Reset();
@@ -720,7 +719,6 @@ namespace WebServiceStudio
                 try
                 {
                     MethodInfo method = currentMethodProperty.GetMethod();
-                    Type declaringType = method.DeclaringType;
                     WSSWebRequest.RequestTrace = properties;
                     var parameters = currentMethodProperty.ReadChildren() as object[];
                     object result = method.Invoke(proxy, BindingFlags.Public, null, parameters, null);

--- a/WebServiceStudio/Wsdl.cs
+++ b/WebServiceStudio/Wsdl.cs
@@ -33,7 +33,7 @@ namespace WebServiceStudio
         private readonly StringCollection wsdls = new StringCollection();
         private readonly StringCollection xsds = new StringCollection();
         private bool cancelled;
-        private CodeDomProvider codeProvider;29
+        private CodeDomProvider codeProvider;
         private CodeCompileUnit compileUnit;
         private Assembly proxyAssembly;
         private string proxyCode = "<NOT YET>";

--- a/WebServiceStudio/Wsdl.cs
+++ b/WebServiceStudio/Wsdl.cs
@@ -20,20 +20,20 @@ namespace WebServiceStudio
 {
     internal class Wsdl
     {
-        private static string duplicateSchema =
+        private static readonly string duplicateSchema =
             "Warning: Ignoring duplicate schema description with TargetNamespace='{0}' from '{1}'.";
 
-        private static string duplicateService =
+        private static readonly string duplicateService =
             "Warning: Ignoring duplicate service description with TargetNamespace='{0}' from '{1}'.";
 
-        private static string schemaValidationFailure =
+        private static readonly string schemaValidationFailure =
             "Schema could not be validated. Class generation may fail or may produce incorrect results";
 
         private readonly StringCollection paths = new StringCollection();
         private readonly StringCollection wsdls = new StringCollection();
         private readonly StringCollection xsds = new StringCollection();
         private bool cancelled;
-        private CodeDomProvider codeProvider;
+        private CodeDomProvider codeProvider;29
         private CodeCompileUnit compileUnit;
         private Assembly proxyAssembly;
         private string proxyCode = "<NOT YET>";


### PR DESCRIPTION
Update security protocols and clean up code

- Set `ServicePointManager.SecurityProtocol` to use `Tls12` and `Tls11`.
- Remove unused `selectedTab` variable assignment in `MainForm.cs`.
- Remove unnecessary `declaringType` variable assignment in `MainForm.cs`.
- Change string variables in `Wsdl.cs` to readonly for immutability.

Closing #29, #30, #31, #32, #33